### PR TITLE
Fixed repeating CSS code display in spec page.

### DIFF
--- a/core/views/sections.ejs
+++ b/core/views/sections.ejs
@@ -7,10 +7,6 @@
     <% } %>
 
     <% if (sections[i].markup) { %>
-        <code class="src-html <% if (config.visibleCode) { %>source_visible<% } %>">
-            <%- sections[i].markup.escaped %>
-        </code>
-
         <div class="source_example">
             <%- sections[i].markup.example %>
         </div>
@@ -26,9 +22,6 @@
                 <p><%= state.description %></p>
             <% } %>
 
-            <code class="src-html <% if (config.visibleCode) { %>source_visible<% } %>">
-                <%= html %>
-            </code>
             <div class="source_example">
                 <%- html %>
             </div>


### PR DESCRIPTION
Markup with <code class=“src-html”> in /views/sections.ejs repeats the
code display and this code display is not controlled by show/hide code
toggle in generated spec page.

Removing this <code> snippet solved the problem.
